### PR TITLE
Fix attic disclaimer

### DIFF
--- a/deploy/nginx.vh.default.conf
+++ b/deploy/nginx.vh.default.conf
@@ -9,7 +9,7 @@ server {
         autoindex on;
         root   /usr/share/nginx/html;
         proxy_set_header Accept-Encoding "";
-        sub_filter '</head>' '<script src="/attic.js"></script><link rel="stylesheet" href="/attic.css"></head>';
+        sub_filter '</head>' '<script src="attic.js"></script><link rel="stylesheet" href="attic.css"></head>';
         sub_filter_once on;
         #index  index.html index.htm;
     }


### PR DESCRIPTION
The javascript and stylesheet should be resolved relative to the files that use them. The absolute reference only works when the content is deployed on the context root of the webservice (which does not happen in production: it lives on `/attic/`)